### PR TITLE
Support node builds

### DIFF
--- a/.changes/next-release/feature-Build-910cd6ed.json
+++ b/.changes/next-release/feature-Build-910cd6ed.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Build",
+  "description": "Build parts of SDK for use in nodejs, similar to browser-builds."
+}

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 var build = require('./builder');
-var path = require('path');
 
-// following is set as default build options: 
+// following is set as default build options:
 // var buildOptions = { basedir: path.resolve(__dirname, '..') };
 
 // run if we called this tool directly

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -1,64 +1,16 @@
 #!/usr/bin/env node
 
+var build = require('./builder');
 var path = require('path');
 
-var AWS = require('../index');
-
-var license = [
-  '// AWS SDK for JavaScript v' + AWS.VERSION,
-  '// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.',
-  '// License at https://sdk.amazonaws.com/js/BUNDLE_LICENSE.txt'
-].join('\n') + '\n';
-
-function minify(code) {
-  var uglify = require('uglify-js');
-  var minified = uglify.minify(code, {fromString: true});
-  return minified.code;
-}
-
-function build(options, callback) {
-  if (arguments.length === 1) {
-    callback = options;
-    options = {};
-  }
-  
-  var img = require('insert-module-globals');
-  img.vars.process = function() { return '{browser:true}'; };
-
-  if (options.services) process.env.AWS_SERVICES = options.services;
-
-  var browserify = require('browserify');
-  var brOpts = { basedir: path.resolve(__dirname, '..'), 
-                  standalone: 'AWS',
-                  detectGlobals: false,
-                  browserField : false,
-                  builtins : false,
-                  ignoreMissing: true,
-                  commondir : false,
-                  insertGlobalVars : {
-                      process: undefined,
-                      global: undefined,
-                      'Buffer.isBuffer': undefined,
-                      Buffer: undefined 
-                  }
-                };
-                
-  browserify(brOpts).add('./').ignore('domain').bundle(function(err, data) {
-    if (err) return callback(err);
-
-    var code = (data || '').toString();
-    if (options.minify) code = minify(code);
-
-    code = license + code;
-    callback(null, code);
-  });
-}
+// following is set as default build options: 
+// var buildOptions = { basedir: path.resolve(__dirname, '..') };
 
 // run if we called this tool directly
 if (require.main === module) {
   var opts = {
     services: process.argv[2] || process.env.SERVICES,
-    minify: process.env.MINIFY ? true : false
+    minify: process.env.MINIFY ? true : false,
   };
 
   build(opts, function(err, code) {
@@ -66,6 +18,3 @@ if (require.main === module) {
     else console.log(code);
   });
 }
-
-build.license = license;
-module.exports = build;

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -17,6 +17,11 @@ function minify(code) {
 }
 
 function build(options, callback) {
+  if (arguments.length === 1) {
+    callback = options;
+    options = {};
+  }
+  
   var img = require('insert-module-globals');
   img.vars.process = function() { return '{browser:true}'; };
 

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -9,7 +9,7 @@ var build = require('./builder');
 if (require.main === module) {
   var opts = {
     services: process.argv[2] || process.env.SERVICES,
-    minify: process.env.MINIFY ? true : false,
+    minify: process.env.MINIFY ? true : false
   };
 
   build(opts, function(err, code) {

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -17,18 +17,27 @@ function minify(code) {
 }
 
 function build(options, callback) {
-  if (arguments.length === 1) {
-    callback = options;
-    options = {};
-  }
-
   var img = require('insert-module-globals');
   img.vars.process = function() { return '{browser:true}'; };
 
   if (options.services) process.env.AWS_SERVICES = options.services;
 
   var browserify = require('browserify');
-  var brOpts = { basedir: path.resolve(__dirname, '..') };
+  var brOpts = { basedir: path.resolve(__dirname, '..'), 
+                  standalone: 'AWS',
+                  detectGlobals: false,
+                  browserField : false,
+                  builtins : false,
+                  ignoreMissing: true,
+                  commondir : false,
+                  insertGlobalVars : {
+                      process: undefined,
+                      global: undefined,
+                      'Buffer.isBuffer': undefined,
+                      Buffer: undefined 
+                  }
+                };
+                
   browserify(brOpts).add('./').ignore('domain').bundle(function(err, data) {
     if (err) return callback(err);
 
@@ -46,6 +55,7 @@ if (require.main === module) {
     services: process.argv[2] || process.env.SERVICES,
     minify: process.env.MINIFY ? true : false
   };
+
   build(opts, function(err, code) {
     if (err) console.error(err.message);
     else console.log(code);

--- a/dist-tools/builder.js
+++ b/dist-tools/builder.js
@@ -21,7 +21,7 @@ function build(options, callback) {
     callback = options;
     options = {};
   }
-  
+
   var img = require('insert-module-globals');
   img.vars.process = function() { return '{browser:true}'; };
 

--- a/dist-tools/builder.js
+++ b/dist-tools/builder.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var path = require('path');
-
 var AWS = require('../index');
 
 var license = [

--- a/dist-tools/builder.js
+++ b/dist-tools/builder.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+var path = require('path');
+
+var AWS = require('../index');
+
+var license = [
+  '// AWS SDK for JavaScript v' + AWS.VERSION,
+  '// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.',
+  '// License at https://sdk.amazonaws.com/js/BUNDLE_LICENSE.txt'
+].join('\n') + '\n';
+
+function minify(code) {
+  var uglify = require('uglify-js');
+  var minified = uglify.minify(code, {fromString: true});
+  return minified.code;
+}
+
+function build(options, callback) {
+  if (arguments.length === 1) {
+    callback = options;
+    options = {};
+  }
+  
+  var img = require('insert-module-globals');
+  img.vars.process = function() { return '{browser:true}'; };
+
+  if (options.services) process.env.AWS_SERVICES = options.services;
+
+  var brOpts = { basedir: path.resolve(__dirname, '..') };
+  if (options.build) brOpts = options.build; // grab specific build options if any
+
+  var browserify = require('browserify');
+  browserify(brOpts).add('./').ignore('domain').bundle(function(err, data) {
+    if (err) return callback(err);
+
+    var code = (data || '').toString();
+    if (options.minify) code = minify(code);
+
+    code = license + code;
+    callback(null, code);
+  });
+}
+
+build.license = license;
+module.exports = build;

--- a/dist-tools/node-builder.js
+++ b/dist-tools/node-builder.js
@@ -3,7 +3,7 @@
 var build = require('./builder');
 var path = require('path');
 
-var buildOptions = { basedir: path.resolve(__dirname, '..'), 
+var buildOptions = { basedir: path.resolve(__dirname, '..'),
                     standalone: 'AWS',
                     detectGlobals: false,
                     browserField : false,
@@ -14,7 +14,7 @@ var buildOptions = { basedir: path.resolve(__dirname, '..'),
                         process: undefined,
                         global: undefined,
                         'Buffer.isBuffer': undefined,
-                        Buffer: undefined 
+                        Buffer: undefined
                     }
                   };
 

--- a/dist-tools/node-builder.js
+++ b/dist-tools/node-builder.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+var build = require('./builder');
+var path = require('path');
+
+var buildOptions = { basedir: path.resolve(__dirname, '..'), 
+                    standalone: 'AWS',
+                    detectGlobals: false,
+                    browserField : false,
+                    builtins : false,
+                    ignoreMissing: true,
+                    commondir : false,
+                    insertGlobalVars : {
+                        process: undefined,
+                        global: undefined,
+                        'Buffer.isBuffer': undefined,
+                        Buffer: undefined 
+                    }
+                  };
+
+// run if we called this tool directly
+if (require.main === module) {
+  var opts = {
+    services: process.argv[2] || process.env.SERVICES,
+    minify: process.env.MINIFY ? true : false,
+  };
+
+  opts.build = buildOptions;
+
+  build(opts, function(err, code) {
+    if (err) console.error(err.message);
+    else console.log(code);
+  });
+}

--- a/dist-tools/test/helpers.coffee
+++ b/dist-tools/test/helpers.coffee
@@ -11,7 +11,6 @@ evalCode = (code, preamble) ->
 
 module.exports =
   AWS: require('../../')
-  build: require('../browser-builder')
   collector: require('../service-collector')
   chai: require('chai')
   evalCode: evalCode

--- a/dist-tools/test/node-builder.mocha.spec.coffee
+++ b/dist-tools/test/node-builder.mocha.spec.coffee
@@ -29,23 +29,19 @@ describe 'build', ->
         result = helpers.evalCode(code, data)
       cb(err, result)
 
-  it 'defaults to no minification', ->
-    buildBundle null, null, 'window.AWS', (err, AWS) ->
-      expect(data).to.match(/Copyright Amazon\.com/i)
-
   it 'can be minified (slow)', ->
     buildBundle null, minify: true, null, ->
       expect(data).to.match(/Copyright Amazon\.com/i) # has license
       expect(data).to.match(/function \w\(\w,\w,\w\)\{function \w\(\w,\w\)\{/)
 
   it 'can build default services into bundle', ->
-    buildBundle null, null, 'window.AWS', (err, AWS) ->
+    buildBundle null, null, 'AWS', (err, AWS) ->
       expect(new AWS.S3().api.apiVersion).to.equal(new helpers.AWS.S3().api.apiVersion)
       expect(new AWS.DynamoDB().api.apiVersion).to.equal(new helpers.AWS.DynamoDB().api.apiVersion)
       expect(new AWS.STS().api.apiVersion).to.equal(new helpers.AWS.STS().api.apiVersion)
 
   it 'can build all services into bundle', ->
-    buildBundle 'all', null, 'window.AWS', (err, AWS) ->
+    buildBundle 'all', null, 'AWS', (err, AWS) ->
       Object.keys(helpers.AWS).forEach (k) ->
         if k.serviceIdentifier
           expect(typeof AWS[k]).to.equal('object')

--- a/dist-tools/test/node-builder.mocha.spec.coffee
+++ b/dist-tools/test/node-builder.mocha.spec.coffee
@@ -1,69 +1,9 @@
 helpers = require('./helpers')
-build = require('../browser-builder')
+build = require('../node-builder')
 collector = helpers.collector
 exec = require('child_process').exec
 fs = require('fs')
 expect = helpers.chai.expect
-
-describe 'ServiceCollector', ->
-  code = null
-
-  add = (services) -> code = collector(services)
-
-  assertServiceAdded = (klass, version) ->
-    version = version || new helpers.AWS[klass](endpoint: 'localhost').api.apiVersion;
-    expect(code).to.match(new RegExp('AWS\\.' + klass +
-      ' = AWS\\.Service\\.defineService\\(\'' +
-      helpers.AWS[klass].serviceIdentifier + '\''))
-    expect(code).to.match(new RegExp(
-      'AWS\\.apiLoader\\.services\\[\'' + klass.toLowerCase() +
-      '\'\\]\\[\'' + version + '\'\\] ='))
-
-  assertBundleFailed = (services, errMsg) ->
-    expect(-> add(services)).to.throw(errMsg)
-
-  it 'accepts comma delimited services by name', ->
-    add 's3,cloudwatch'
-    assertServiceAdded 'S3'
-    assertServiceAdded 'CloudWatch'
-    assertServiceAdded 'STS' # STS always added
-
-  it 'uses latest service version if version suffix is not supplied', ->
-    add 'rds'
-    assertServiceAdded 'RDS'
-
-  it 'accepts fully qualified service-version pair', ->
-    add 'rds-2013-09-09'
-    assertServiceAdded 'RDS', '2013-09-09'
-
-  it 'accepts "all" for all services', ->
-    add 'all'
-    Object.keys(helpers.AWS).forEach (name) ->
-      if helpers.AWS[name].serviceIdentifier
-        assertServiceAdded(name)
-
-  it 'throws an error if the service does not exist', ->
-    assertBundleFailed 'invalidmodule', 'Missing modules: invalidmodule'
-
-  it 'throws an error if the service version does not exist', ->
-    services = 's3-1999-01-01'
-    msg = 'Missing modules: s3-1999-01-01'
-    assertBundleFailed(services, msg)
-
-  it 'groups multiple errors into one error object', ->
-    services = 's3-1999-01-01,invalidmodule,dynamodb-01-01-01'
-    msg = 'Missing modules: dynamodb-01-01-01, invalidmodule, s3-1999-01-01'
-    assertBundleFailed(services, msg)
-
-  it 'throws an opaque error if special characters are found (/, ., *)', ->
-    msg = 'Incorrectly formatted service names'
-    assertBundleFailed('path/to/service', msg)
-    assertBundleFailed('to/../../../root', msg)
-    assertBundleFailed('*.js', msg)
-    assertBundleFailed('a.b', msg)
-    assertBundleFailed('a=b', msg)
-    assertBundleFailed('!d', msg)
-    assertBundleFailed('valid1,valid2,invalid.module', msg)
 
 describe 'build', ->
   bundleCache = {}
@@ -112,13 +52,14 @@ describe 'build', ->
 
   describe 'as executable', ->
     cwd = __dirname + '/../'
-    script = './browser-builder.js '
+    script = './node-builder.js '
 
     it 'uses first argument to get services list', (done)  ->
       exec script + 'iam-2010-05-08', cwd: cwd, maxBuffer: 999999999, (e, out) ->
         expect(out).to.match(/Copyright Amazon\.com/i)
         expect(out).to.contain('"2010-05-08"')
         expect(out).not.to.contain('"2006-03-01"')
+        expect(out).not.to.contaion('XMLHttpRequest')
         done()
 
     it 'uses MINIFY environment variable to set minification mode', (done) ->
@@ -128,4 +69,5 @@ describe 'build', ->
         expect(out).to.match(/Copyright Amazon\.com/i)
         expect(out).to.match(/function \w\(\w,\w,\w\)\{function \w\(\w,\w\)\{/)
         expect(out).to.contain('"2006-03-01"')
+        expect(out).not.to.contaion('XMLHttpRequest')
         done()

--- a/dist-tools/test/node-builder.mocha.spec.coffee
+++ b/dist-tools/test/node-builder.mocha.spec.coffee
@@ -59,7 +59,7 @@ describe 'build', ->
         expect(out).to.match(/Copyright Amazon\.com/i)
         expect(out).to.contain('"2010-05-08"')
         expect(out).not.to.contain('"2006-03-01"')
-        expect(out).not.to.contaion('XMLHttpRequest')
+        expect(out).not.to.contain('XMLHttpRequest')
         done()
 
     it 'uses MINIFY environment variable to set minification mode', (done) ->
@@ -69,5 +69,5 @@ describe 'build', ->
         expect(out).to.match(/Copyright Amazon\.com/i)
         expect(out).to.match(/function \w\(\w,\w,\w\)\{function \w\(\w,\w\)\{/)
         expect(out).to.contain('"2006-03-01"')
-        expect(out).not.to.contaion('XMLHttpRequest')
+        expect(out).not.to.contain('XMLHttpRequest')
         done()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Adds a script, `node-builder.js`, similar to `browser-builder.js`, to build only parts of the SDK. We needed this to reduce the size of our dependencies, since we use only some services. I therefore added a script that builds a version for node only (+refactored so that node and browser builds use the same underlying functions, but with different parameters for the browserify part). 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated (no change needed)
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed (no change)
- [ ] run `npm run integration` if integration test is changed (no change)
- [ ] non-code related change (markdown/git settings etc)
